### PR TITLE
Build librespot 0.4.2 in container (fixes #589)

### DIFF
--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -1,6 +1,36 @@
-FROM tmigone/librespot:0.3.1-pulseaudio
+ARG BALENA_ARCH=%%BALENA_ARCH%%
+
+# Build process from: https://git.alpinelinux.org/aports/tree/testing/librespot/APKBUILD
+FROM balenalib/$BALENA_ARCH-alpine:3.16 as librespot-builder
+WORKDIR /app
+
+ARG LIBRESPOT_VERSION=0.4.2
+
+RUN install_packages alsa-lib-dev pulseaudio-dev cargo curl
+
+RUN curl -sL "https://github.com/librespot-org/librespot/archive/refs/tags/v${LIBRESPOT_VERSION}.tar.gz" --output librespot.tar.gz && \
+    mkdir /app/librespot-src && \
+    tar -zxvf librespot.tar.gz --directory /app/librespot-src --strip-components=1
+
+WORKDIR /app/librespot-src
+
+ENV CARGO_HOME=/app/cargo
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+RUN cargo build \
+    --release \
+    --features alsa-backend,pulseaudio-backend \
+    --verbose
+
+
+FROM balenalib/$BALENA_ARCH-alpine:3.14-run
+WORKDIR /app
 
 ENV PULSE_SERVER=tcp:localhost:4317
+
+RUN install_packages libgcc alsa-lib-dev pulseaudio-dev
+
+COPY --from=librespot-builder /app/librespot-src/target/release/librespot /usr/bin/librespot
 
 COPY start.sh /usr/src/
 


### PR DESCRIPTION
Spotify playback is broken in librespot 0.3.1 and depending on tmigone/librespot:0.3.1-pulseaudio means we can't easily upgrade to the latest version.

Building within the project allows us to choose which version is tracked by balena-sound, [as suggested here](https://github.com/balena-labs-projects/balena-sound/issues/589#issuecomment-1310072186).

I pushed this to a balena device and it builds correctly and plays Spotify.

Fixes #589