### PR TITLE
Use a pre-built librespot image

### DIFF
--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -1,36 +1,6 @@
-ARG BALENA_ARCH=%%BALENA_ARCH%%
-
-# Build process from: https://git.alpinelinux.org/aports/tree/testing/librespot/APKBUILD
-FROM balenalib/$BALENA_ARCH-alpine:3.16 as librespot-builder
-WORKDIR /app
-
-ARG LIBRESPOT_VERSION=0.4.2
-
-RUN install_packages alsa-lib-dev pulseaudio-dev cargo curl
-
-RUN curl -sL "https://github.com/librespot-org/librespot/archive/refs/tags/v${LIBRESPOT_VERSION}.tar.gz" --output librespot.tar.gz && \
-    mkdir /app/librespot-src && \
-    tar -zxvf librespot.tar.gz --directory /app/librespot-src --strip-components=1
-
-WORKDIR /app/librespot-src
-
-ENV CARGO_HOME=/app/cargo
-ENV RUSTFLAGS="-C target-feature=-crt-static"
-
-RUN cargo build \
-    --release \
-    --features alsa-backend,pulseaudio-backend \
-    --verbose
-
-
-FROM balenalib/$BALENA_ARCH-alpine:3.14-run
-WORKDIR /app
+FROM andrewn/librespot:0.4.2-pulseaudio
 
 ENV PULSE_SERVER=tcp:localhost:4317
-
-RUN install_packages libgcc alsa-lib-dev pulseaudio-dev
-
-COPY --from=librespot-builder /app/librespot-src/target/release/librespot /usr/bin/librespot
 
 COPY start.sh /usr/src/
 


### PR DESCRIPTION
I have no idea why the `librespot` building isn't working (implemented in PR #610) causing issues #611 and #612.

### Option 1:

I think we should switch to the pre-built images of v0.4.2.

[There's a list of architectures here](https://hub.docker.com/r/andrewn/librespot/tags).

[I used this script](https://github.com/andrewn/librespot-docker/blob/andrewn/librespot-v0.4.2/scripts/build-pulseaudio.sh) and have been running on a Pi model 3 A+ for a few months.

### Option 2:

Open a PR to revert commit 9f8c623c7c6778e19ce20a99e4b0029bb85e316b. 



@maggie0002 it's up to you. Sorry about messing things up :-( 

(fixes #611, #612)
