### PR TITLE
Add Airplay 2 support - Upgrade shairport version

### DIFF
--- a/plugins/airplay/Dockerfile.template
+++ b/plugins/airplay/Dockerfile.template
@@ -1,19 +1,20 @@
-FROM mikebrady/shairport-sync:3.3.8 as shairport
+FROM mikebrady/shairport-sync:4.1.1 as shairport
 WORKDIR /usr/src
 
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 # DL4006: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/sh", "-eo", "pipefail", "-c"]
 
 # shairport-sync docker image doesn't include pulseaudio support so we use ALSA bridge
 ENV PULSE_SERVER=tcp:localhost:4317
-RUN apk add --no-cache curl~=7 && \
+RUN apk add --no-cache supervisor curl~=7 && \
   curl -skL https://raw.githubusercontent.com/balena-labs-projects/audio/master/scripts/alsa-bridge/alpine-setup.sh | sh \
   && apk del curl
 
 COPY start.sh /usr/src/
+COPY supervisor.conf /usr/src/supervisor.conf
 
 # shairport-sync image entrypoint starts dbus and avahi daemons that we don't need
 ENTRYPOINT []
-CMD [ "/bin/ash", "/usr/src/start.sh" ]
+CMD ["supervisord","-c","/usr/src/supervisor.conf"]

--- a/plugins/airplay/start.sh
+++ b/plugins/airplay/start.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/usr/bin/env sh
 
 if [[ -n "$SOUND_DISABLE_AIRPLAY" ]]; then
   echo "Airplay is disabled, exiting..."
@@ -13,8 +13,8 @@ echo "Starting AirPlay plugin..."
 echo "Device name: $SOUND_DEVICE_NAME"
 
 # Start AirPlay
+echo "Starting Shairport Sync"
 exec shairport-sync \
-  --use-stderr \
   --name "$SOUND_DEVICE_NAME" \
   --output alsa \
   -- -d pulse \

--- a/plugins/airplay/supervisor.conf
+++ b/plugins/airplay/supervisor.conf
@@ -1,0 +1,20 @@
+[supervisord]  
+nodaemon=true 
+root=true
+
+[program:shairport-sync]
+command=/bin/sh /usr/src/start.sh
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0
+
+[program:nqptp] 
+command=nqptp
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0


### PR DESCRIPTION
# Add AirPlay 2 support 

## Description 
Following https://github.com/balena-labs-projects/balena-sound/issues/607  
This is an attempt to bring airplay 2 support to balena sound. 

## What's working ?

### Current setup 

- a Raspberry pi 4 + hifiberry DAC, that is my current multiroom master 
- a raspberry pi zero w + hifiberry miniamp, that is a multiroom client

### Features tested 

- [x] Streaming to a single client
- [x] Streaming to multiple clients at once 
- [x] Select volume on each client 

I tested all this with `SOUND_MODE=standalone` and `SOUND_MODE=MULTI_ROOM` or `SOUND_MODE=MULTI_ROOM_CLIENT`

### Issues
I noticed even before this upgrade that my raspberry pi zero had high CPU usage, and the sound was stuttering while streaming as a multiroom client. 
I was not able to properly test the sound output for this device, the stuttering persisted after the shairport's version upgrade. I am pretty sure this is a different issue, but I would be glad if other users tested on their properly working Rpi zero to ensure this is not an issue caused by these changes. 

## How to test it locally 

1. Install [Balena Cloud CLI](https://github.com/balena-io/balena-cli) 
2. Clone my repo `git clone -b feature/bring-airplay-2-support https://github.com/fabienheureux/balena-sound.git`
3. Go to the repo directory `cd balena-sound` 
4. Publish it to your fleet using the cli `balena push YOUR_FLEET_NAME`
5. Check on the dashboard that airplay is downloaded and properly restarted
6. Enjoy 🎉 
