### PR TITLE
fix for bug 626 - Spotify customization variables

### DIFF
--- a/plugins/spotify/start.sh
+++ b/plugins/spotify/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "$SOUND_DISABLE_SPOTIFY" ]]; then
   echo "Spotify is disabled, exiting..."
@@ -11,8 +11,8 @@ fi
 SOUND_DEVICE_NAME=${SOUND_DEVICE_NAME:-"balenaSound Spotify $(echo "$BALENA_DEVICE_UUID" | cut -c -4)"}
 SOUND_SPOTIFY_BITRATE=${SOUND_SPOTIFY_BITRATE:-160}
 
-# SOUND_SPOTIFY_DISABLE_NORMALISATION: Disable volume normalisation
-if [[ -z "$SOUND_SPOTIFY_DISABLE_NORMALISATION" ]]; then
+# SOUND_SPOTIFY_DISABLE_NORMALISATION: Disable volume normalization
+if [[ -z ${SOUND_SPOTIFY_DISABLE_NORMALISATION+x} ]]; then
   set -- "$@" \
     --enable-volume-normalisation
 fi
@@ -25,8 +25,8 @@ if [[ -n "$SOUND_SPOTIFY_USERNAME" ]] && [[ -n "$SOUND_SPOTIFY_PASSWORD" ]]; the
     --password "$SOUND_SPOTIFY_PASSWORD"
 fi
 
-# SOUND_SPOTIFY_DISABLE_CACHE: Disable Spotify audio cache
-if [[ -z "$SOUND_SPOTIFY_ENABLE_CACHE" ]]; then
+# SOUND_SPOTIFY_ENABLE_CACHE: Enable Spotify audio cache
+if [[ -z ${SOUND_SPOTIFY_ENABLE_CACHE+x} ]]; then
   set -- "$@" \
     --disable-audio-cache
 fi
@@ -36,8 +36,8 @@ fi
 echo "Starting Spotify plugin..."
 echo "Device name: $SOUND_DEVICE_NAME"
 [[ -n "$SOUND_SPOTIFY_USERNAME" ]] && [[ -n "$SOUND_SPOTIFY_PASSWORD" ]] && echo "Using provided credentials for Spotify login."
-[[ -z "$SOUND_SPOTIFY_DISABLE_NORMALISATION" ]] && echo "Volume normalization enabled."
-[[ -z "$SOUND_SPOTIFY_ENABLE_CACHE" ]] && echo "Spotify audio cache disabled."
+[[ -n ${SOUND_SPOTIFY_DISABLE_NORMALISATION+x} ]] && echo "Volume normalization disabled."
+[[ -n ${SOUND_SPOTIFY_ENABLE_CACHE+x} ]] && echo "Spotify audio cache enabled."
 
 set -- /usr/bin/librespot \
   --backend pulseaudio \


### PR DESCRIPTION
Fix for Spotify customization variables **SOUND_SPOTIFY_DISABLE_NORMALISATION** and **SOUND_SPOTIFY_ENABLE_CACHE**. Now the variables can be defined and have no value and work correctly.

Closes: https://github.com/balena-labs-projects/balena-sound/issues/626